### PR TITLE
Support ARNs which contain commas

### DIFF
--- a/src/commands/endpoints/access/add.ts
+++ b/src/commands/endpoints/access/add.ts
@@ -17,8 +17,8 @@ export default class EndpointsAccessAdd extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:access:add postgresql-rigid-37567 --account_ids 123456',
-    '$ heroku endpoints:access:add postgresql-rigid-37567 --account_ids 123456 78910',
+    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-ids 12345:user/abc',
+    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-ids "12345:user/abc 45678:user/xyz" # multiple account ids must be in "quotes"',
   ]
 
   async run() {

--- a/src/commands/endpoints/access/add.ts
+++ b/src/commands/endpoints/access/add.ts
@@ -13,7 +13,7 @@ export default class EndpointsAccessAdd extends BaseCommand {
 
   static flags = {
     'account-id': flags.build({
-      char: 'A',
+      char: 'i',
       description: 'account id to use',
       parse: (input: string, ctx: any) => {
         if (!ctx.endpoints_access_add_ids) ctx.endpoints_access_add_ids = []

--- a/src/commands/endpoints/access/add.ts
+++ b/src/commands/endpoints/access/add.ts
@@ -18,18 +18,19 @@ export default class EndpointsAccessAdd extends BaseCommand {
 
   static examples = [
     '$ heroku endpoints:access:add postgresql-rigid-37567 --account_ids 123456',
-    '$ heroku endpoints:access:add postgresql-rigid-37567 --account_ids 123456,78910',
+    '$ heroku endpoints:access:add postgresql-rigid-37567 --account_ids 123456 78910',
   ]
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessAdd)
     const database = args.database || await fetcher(this.heroku, flags.app)
-
-    cli.action.start('Adding account to the whitelist')
+    const account_ids = flags['account-ids'].split(' ').map((account: any) => account.trim())
+    const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
+    cli.action.start(`Adding ${accountFormatted} to the whitelist`)
     await this.heroku.put(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
       ...this.heroku.defaults,
       body: {
-        whitelisted_accounts: [flags['account-ids']]
+        whitelisted_accounts: account_ids
       }
     })
     cli.action.stop()

--- a/src/commands/endpoints/access/add.ts
+++ b/src/commands/endpoints/access/add.ts
@@ -13,7 +13,7 @@ export default class EndpointsAccessAdd extends BaseCommand {
 
   static flags = {
     'account-id': flags.build({
-      char: 'a',
+      char: 'A',
       description: 'account id to use',
       parse: (input: string, ctx: any) => {
         if (!ctx.endpoints_access_add_ids) ctx.endpoints_access_add_ids = []

--- a/src/commands/endpoints/access/add.ts
+++ b/src/commands/endpoints/access/add.ts
@@ -25,8 +25,8 @@ export default class EndpointsAccessAdd extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-id 12345:user/abc',
-    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-id 12345:user/abc --account-id 45678:user/xyz',
+    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-id 123456789012:user/abc',
+    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-id 123456789012:user/abc --account-id 123456789012:user/xyz',
   ]
 
   async run() {

--- a/src/commands/endpoints/access/add.ts
+++ b/src/commands/endpoints/access/add.ts
@@ -12,20 +12,29 @@ export default class EndpointsAccessAdd extends BaseCommand {
   ]
 
   static flags = {
-    'account-ids': flags.string({required: true}),
+    'account-id': flags.build({
+      char: 'a',
+      description: 'account id to use',
+      parse: (input: string, ctx: any) => {
+        if (!ctx.endpoints_access_add_ids) ctx.endpoints_access_add_ids = []
+        ctx.endpoints_access_add_ids.push(input)
+        return ctx.endpoints_access_add_ids
+      },
+    })(),
     app: flags.app({required: true})
   }
 
   static examples = [
-    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-ids 12345:user/abc',
-    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-ids "12345:user/abc 45678:user/xyz" # multiple account ids must be in "quotes"',
+    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-id 12345:user/abc',
+    '$ heroku endpoints:access:add postgresql-sushi-12345 --account-id 12345:user/abc --account-id 45678:user/xyz',
   ]
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessAdd)
     const database = args.database || await fetcher(this.heroku, flags.app)
-    const account_ids = flags['account-ids'].split(' ').map((account: any) => account.trim())
+    const account_ids = flags['account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
+
     cli.action.start(`Adding ${accountFormatted} to the whitelist`)
     await this.heroku.put(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
       ...this.heroku.defaults,

--- a/src/commands/endpoints/access/index.ts
+++ b/src/commands/endpoints/access/index.ts
@@ -16,7 +16,7 @@ export default class EndpointsAccessIndex extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:access postgresql-rigid-37567',
+    '$ heroku endpoints:access postgresql-sushi-12345',
   ]
 
   async run() {

--- a/src/commands/endpoints/access/remove.ts
+++ b/src/commands/endpoints/access/remove.ts
@@ -25,8 +25,8 @@ export default class EndpointsAccessRemove extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-id 12345:user/xyz',
-    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-id 12345:user/abc --account-id 45678:user/xyz',
+    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-id 123456789012:user/xyz',
+    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-id 123456789012:user/abc --account-id 123456789012:user/xyz',
   ]
 
   async run() {

--- a/src/commands/endpoints/access/remove.ts
+++ b/src/commands/endpoints/access/remove.ts
@@ -13,7 +13,7 @@ export default class EndpointsAccessRemove extends BaseCommand {
 
   static flags = {
     'account-id': flags.build({
-      char: 'a',
+      char: 'A',
       description: 'account id to use',
       parse: (input: string, ctx: any) => {
         if (!ctx.endpoints_access_remove_ids) ctx.endpoints_access_remove_ids = []

--- a/src/commands/endpoints/access/remove.ts
+++ b/src/commands/endpoints/access/remove.ts
@@ -23,12 +23,13 @@ export default class EndpointsAccessRemove extends BaseCommand {
   async run() {
     const {args, flags} = this.parse(EndpointsAccessRemove)
     const database = args.database || await fetcher(this.heroku, flags.app)
-
-    cli.action.start('Removing account from the whitelist')
+    const account_ids = flags['account-ids'].split(' ').map((account: any) => account.trim())
+    const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
+    cli.action.start(`Removing ${accountFormatted} from the whitelist`)
     await this.heroku.patch(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
       ...this.heroku.defaults,
       body: {
-        whitelisted_accounts: [flags['account-ids']]
+        whitelisted_accounts: account_ids
       }
     })
     cli.action.stop()

--- a/src/commands/endpoints/access/remove.ts
+++ b/src/commands/endpoints/access/remove.ts
@@ -17,13 +17,14 @@ export default class EndpointsAccessRemove extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:access:remove --account_ids arn:aws:iam::12345678910:root',
+    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-ids 12345:user/xyz',
+    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-ids "12345:user/abc 45678:user/xyz" # multiple account ids must be in "quotes"',
   ]
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessRemove)
     const database = args.database || await fetcher(this.heroku, flags.app)
-    const account_ids = flags['account-ids'].split(' ').map((account: any) => account.trim())
+    const account_ids = flags['account-ids'].split(' ')
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
     cli.action.start(`Removing ${accountFormatted} from the whitelist`)
     await this.heroku.patch(`/private-link/v0/databases/${database}/whitelisted_accounts`, {

--- a/src/commands/endpoints/access/remove.ts
+++ b/src/commands/endpoints/access/remove.ts
@@ -12,20 +12,29 @@ export default class EndpointsAccessRemove extends BaseCommand {
   ]
 
   static flags = {
-    'account-ids': flags.string({required: true}),
+    'account-id': flags.build({
+      char: 'a',
+      description: 'account id to use',
+      parse: (input: string, ctx: any) => {
+        if (!ctx.endpoints_access_remove_ids) ctx.endpoints_access_remove_ids = []
+        ctx.endpoints_access_remove_ids.push(input)
+        return ctx.endpoints_access_remove_ids
+      },
+    })(),
     app: flags.app({required: true})
   }
 
   static examples = [
-    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-ids 12345:user/xyz',
-    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-ids "12345:user/abc 45678:user/xyz" # multiple account ids must be in "quotes"',
+    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-id 12345:user/xyz',
+    '$ heroku endpoints:access:remove postgresql-sushi-12345 --account-id 12345:user/abc --account-id 45678:user/xyz',
   ]
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessRemove)
     const database = args.database || await fetcher(this.heroku, flags.app)
-    const account_ids = flags['account-ids'].split(' ')
+    const account_ids = flags['account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
+
     cli.action.start(`Removing ${accountFormatted} from the whitelist`)
     await this.heroku.patch(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
       ...this.heroku.defaults,

--- a/src/commands/endpoints/access/remove.ts
+++ b/src/commands/endpoints/access/remove.ts
@@ -13,7 +13,7 @@ export default class EndpointsAccessRemove extends BaseCommand {
 
   static flags = {
     'account-id': flags.build({
-      char: 'A',
+      char: 'i',
       description: 'account id to use',
       parse: (input: string, ctx: any) => {
         if (!ctx.endpoints_access_remove_ids) ctx.endpoints_access_remove_ids = []

--- a/src/commands/endpoints/create.ts
+++ b/src/commands/endpoints/create.ts
@@ -14,7 +14,7 @@ export default class EndpointsCreate extends BaseCommand {
 
   static flags = {
     'account-id': flags.build({
-      char: 'a',
+      char: 'A',
       description: 'account id to use',
       parse: (input: string, ctx: any) => {
         if (!ctx.endpoints_create_ids) ctx.endpoints_create_ids = []

--- a/src/commands/endpoints/create.ts
+++ b/src/commands/endpoints/create.ts
@@ -18,12 +18,13 @@ export default class EndpointsCreate extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:create',
+    '$ heroku endpoints:create postgresql-sushi-12345 --account-ids 12345:user/abc --app trusted-vpc-endpoint-demo',
+    '$ heroku endpoints:create postgresql-sushi-12345 --account-ids 12345:user/abc 45678:user/xyz --app trusted-vpc-endpoint-demo',
   ]
 
   async run() {
     const {args, flags} = this.parse(EndpointsCreate)
-    const account_ids = flags['account-ids'].split(',').map((account: any) => account.trim())
+    const account_ids = flags['account-ids'].split(' ').map((account: any) => account.trim())
     const database = args.database || await fetcher(this.heroku, flags.app)
 
     cli.action.start('Creating Trusted VPC Endpoint')

--- a/src/commands/endpoints/create.ts
+++ b/src/commands/endpoints/create.ts
@@ -18,17 +18,16 @@ export default class EndpointsCreate extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:create postgresql-sushi-12345 --account-ids 12345:user/abc --app trusted-vpc-endpoint-demo',
-    '$ heroku endpoints:create postgresql-sushi-12345 --account-ids 12345:user/abc 45678:user/xyz --app trusted-vpc-endpoint-demo',
+    '$ heroku endpoints:create postgresql-sushi-12345 --account-ids 12345:user/abc',
+    '$ heroku endpoints:create postgresql-sushi-12345 --account-ids "12345:user/abc 45678:user/xyz" # multiple account ids must be in "quotes"',
   ]
 
   async run() {
     const {args, flags} = this.parse(EndpointsCreate)
-    const account_ids = flags['account-ids'].split(' ').map((account: any) => account.trim())
+    const account_ids = flags['account-ids'].split(' ')
     const database = args.database || await fetcher(this.heroku, flags.app)
 
     cli.action.start('Creating Trusted VPC Endpoint')
-
     const {body: res} = await this.heroku.post<PrivateLinkDB>(`/private-link/v0/databases/${database}`, {
       ...this.heroku.defaults,
       body: {

--- a/src/commands/endpoints/create.ts
+++ b/src/commands/endpoints/create.ts
@@ -26,8 +26,8 @@ export default class EndpointsCreate extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:create postgresql-sushi-12345 --account-id 12345:user/abc',
-    '$ heroku endpoints:create postgresql-sushi-12345 --account-id 12345:user/abc --account-id 45678:user/xyz',
+    '$ heroku endpoints:create postgresql-sushi-12345 --account-id 123456789012:user/abc',
+    '$ heroku endpoints:create postgresql-sushi-12345 --account-id 123456789012:user/abc --account-id 123456789012:user/xyz',
   ]
 
   async run() {

--- a/src/commands/endpoints/create.ts
+++ b/src/commands/endpoints/create.ts
@@ -14,7 +14,7 @@ export default class EndpointsCreate extends BaseCommand {
 
   static flags = {
     'account-id': flags.build({
-      char: 'A',
+      char: 'i',
       description: 'account id to use',
       parse: (input: string, ctx: any) => {
         if (!ctx.endpoints_create_ids) ctx.endpoints_create_ids = []

--- a/src/commands/endpoints/destroy.ts
+++ b/src/commands/endpoints/destroy.ts
@@ -16,7 +16,7 @@ export default class EndpointsDestroy extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:destroy',
+    '$ heroku endpoints:destroy postgresql-sushi-12345',
   ]
 
   async run() {

--- a/src/commands/endpoints/index.ts
+++ b/src/commands/endpoints/index.ts
@@ -17,7 +17,7 @@ export default class EndpointsIndex extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints',
+    '$ heroku endpoints postgresql-sushi-12345',
   ]
 
   async run() {

--- a/src/commands/endpoints/wait.ts
+++ b/src/commands/endpoints/wait.ts
@@ -16,7 +16,7 @@ export default class EndpointsWait extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku endpoints:wait',
+    '$ heroku endpoints:wait postgresql-sushi-12345',
   ]
 
   async run() {

--- a/test/commands/endpoints/access/add.test.ts
+++ b/test/commands/endpoints/access/add.test.ts
@@ -3,24 +3,24 @@ import {expect, test} from '../../../test'
 describe('endpoints:access:add', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .put('/private-link/v0/databases/postgres-123/whitelisted_accounts')
+      .put('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:root']})
       .reply(200, {})
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:add', 'postgres-123', '--account-id', '123456789:root', '--app', 'myapp'])
+    .command(['endpoints:access:add', 'postgres-123', '--account-id', '123456789012:root', '--app', 'myapp'])
     .it('adds an account to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding account to the whitelist... done')
     })
 
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .put('/private-link/v0/databases/postgres-123/whitelisted_accounts')
+      .put('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:add', 'postgres-123', '--account-id', '"123456789:resource1', '--account-id', '123456789:resource2"', '--app', 'myapp'])
+    .command(['endpoints:access:add', 'postgres-123', '--account-id', '123456789012:resource1', '--account-id', '123456789012:resource2', '--app', 'myapp'])
     .it('adds multiple accounts to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding accounts to the whitelist... done')
     })

--- a/test/commands/endpoints/access/add.test.ts
+++ b/test/commands/endpoints/access/add.test.ts
@@ -8,7 +8,7 @@ describe('endpoints:access:add', () => {
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:add', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:root', '--app', 'myapp'])
+    .command(['endpoints:access:add', 'postgres-123', '--account-ids', '123456789:root', '--app', 'myapp'])
     .it('adds an account to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding account to the whitelist... done')
     })
@@ -20,7 +20,7 @@ describe('endpoints:access:add', () => {
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:add', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:resource1 arn:aws:iam::123456789:resource2', '--app', 'myapp'])
+    .command(['endpoints:access:add', 'postgres-123', '--account-ids', '"123456789:resource1 123456789:resource2"', '--app', 'myapp'])
     .it('adds multiple accounts to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding accounts to the whitelist... done')
     })

--- a/test/commands/endpoints/access/add.test.ts
+++ b/test/commands/endpoints/access/add.test.ts
@@ -12,4 +12,16 @@ describe('endpoints:access:add', () => {
     .it('adds an account to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding account to the whitelist... done')
     })
+
+  test
+    .nock('https://postgres-api.heroku.com', api => api
+      .put('/private-link/v0/databases/postgres-123/whitelisted_accounts')
+      .reply(200, {})
+    )
+    .stdout()
+    .stderr()
+    .command(['endpoints:access:add', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:resource1 arn:aws:iam::123456789:resource2', '--app', 'myapp'])
+    .it('adds multiple accounts to the whitelist', ctx => {
+      expect(ctx.stderr).to.contain('Adding accounts to the whitelist... done')
+    })
 })

--- a/test/commands/endpoints/access/add.test.ts
+++ b/test/commands/endpoints/access/add.test.ts
@@ -8,7 +8,7 @@ describe('endpoints:access:add', () => {
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:add', 'postgres-123', '--account-ids', '123456789:root', '--app', 'myapp'])
+    .command(['endpoints:access:add', 'postgres-123', '--account-id', '123456789:root', '--app', 'myapp'])
     .it('adds an account to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding account to the whitelist... done')
     })
@@ -20,7 +20,7 @@ describe('endpoints:access:add', () => {
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:add', 'postgres-123', '--account-ids', '"123456789:resource1 123456789:resource2"', '--app', 'myapp'])
+    .command(['endpoints:access:add', 'postgres-123', '--account-id', '"123456789:resource1', '--account-id', '123456789:resource2"', '--app', 'myapp'])
     .it('adds multiple accounts to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding accounts to the whitelist... done')
     })

--- a/test/commands/endpoints/access/remove.test.ts
+++ b/test/commands/endpoints/access/remove.test.ts
@@ -8,7 +8,7 @@ describe('endpoints:access:remove', () => {
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:remove', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:root', '--app', 'myapp'])
+    .command(['endpoints:access:remove', 'postgres-123', '--account-id', 'arn:aws:iam::123456789:root', '--app', 'myapp'])
     .it('removes an account from the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Removing account from the whitelist... done')
     })
@@ -20,7 +20,7 @@ describe('endpoints:access:remove', () => {
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:remove', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:resource1 arn:aws:iam::123456789:resource2', '--app', 'myapp'])
+    .command(['endpoints:access:remove', 'postgres-123', '--account-id', 'arn:aws:iam::123456789:resource1', '--account-id', 'arn:aws:iam::123456789:resource2', '--app', 'myapp'])
     .it('removes multiple accounts from the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Removing accounts from the whitelist... done')
     })

--- a/test/commands/endpoints/access/remove.test.ts
+++ b/test/commands/endpoints/access/remove.test.ts
@@ -3,24 +3,24 @@ import {expect, test} from '../../../test'
 describe('endpoints:access:remove', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts')
+      .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:root']})
       .reply(200, {})
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:remove', 'postgres-123', '--account-id', 'arn:aws:iam::123456789:root', '--app', 'myapp'])
+    .command(['endpoints:access:remove', 'postgres-123', '--account-id', '123456789012:root', '--app', 'myapp'])
     .it('removes an account from the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Removing account from the whitelist... done')
     })
 
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts')
+      .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
     )
     .stdout()
     .stderr()
-    .command(['endpoints:access:remove', 'postgres-123', '--account-id', 'arn:aws:iam::123456789:resource1', '--account-id', 'arn:aws:iam::123456789:resource2', '--app', 'myapp'])
+    .command(['endpoints:access:remove', 'postgres-123', '--account-id', '123456789012:resource1', '--account-id', '123456789012:resource2', '--app', 'myapp'])
     .it('removes multiple accounts from the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Removing accounts from the whitelist... done')
     })

--- a/test/commands/endpoints/access/remove.test.ts
+++ b/test/commands/endpoints/access/remove.test.ts
@@ -12,4 +12,16 @@ describe('endpoints:access:remove', () => {
     .it('removes an account from the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Removing account from the whitelist... done')
     })
+
+  test
+    .nock('https://postgres-api.heroku.com', api => api
+      .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts')
+      .reply(200, {})
+    )
+    .stdout()
+    .stderr()
+    .command(['endpoints:access:remove', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:resource1 arn:aws:iam::123456789:resource2', '--app', 'myapp'])
+    .it('removes multiple accounts from the whitelist', ctx => {
+      expect(ctx.stderr).to.contain('Removing accounts from the whitelist... done')
+    })
 })

--- a/test/commands/endpoints/create.test.ts
+++ b/test/commands/endpoints/create.test.ts
@@ -8,7 +8,7 @@ describe('endpoints:create', () => {
     )
     .stderr()
     .stdout()
-    .command(['endpoints:create', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:root', '--app', 'myapp'])
+    .command(['endpoints:create', 'postgres-123', '--account-id', 'arn:aws:iam::123456789:root', '--app', 'myapp'])
     .it('creates a trusted VPC endpoint with one account id', ctx => {
       expect(ctx.stderr).to.contain('Creating Trusted VPC Endpoint... done')
     })
@@ -20,7 +20,7 @@ describe('endpoints:create', () => {
     )
     .stderr()
     .stdout()
-    .command(['endpoints:create', 'postgres-123', '--account-ids', '"arn:aws:iam::123456789:resource1 arn:aws:iam::123456789:resource2"', '--app', 'myapp'])
+    .command(['endpoints:create', 'postgres-123', '--account-id', '"arn:aws:iam::123456789:resource1', '--account-id', 'arn:aws:iam::123456789:resource2"', '--app', 'myapp'])
     .it('creates a trusted VPC endpoint with multiple account ids', ctx => {
       expect(ctx.stderr).to.contain('Creating Trusted VPC Endpoint... done')
     })

--- a/test/commands/endpoints/create.test.ts
+++ b/test/commands/endpoints/create.test.ts
@@ -9,7 +9,19 @@ describe('endpoints:create', () => {
     .stderr()
     .stdout()
     .command(['endpoints:create', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:root', '--app', 'myapp'])
-    .it('creates a trusted VPC endpoint', ctx => {
+    .it('creates a trusted VPC endpoint with one account id', ctx => {
+      expect(ctx.stderr).to.contain('Creating Trusted VPC Endpoint... done')
+    })
+
+  test
+    .nock('https://postgres-api.heroku.com', api => api
+      .post('/private-link/v0/databases/postgres-123')
+      .reply(200, {})
+    )
+    .stderr()
+    .stdout()
+    .command(['endpoints:create', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:resource1 arn:aws:iam::123456789:resource2', '--app', 'myapp'])
+    .it('creates a trusted VPC endpoint with multiple account ids', ctx => {
       expect(ctx.stderr).to.contain('Creating Trusted VPC Endpoint... done')
     })
 })

--- a/test/commands/endpoints/create.test.ts
+++ b/test/commands/endpoints/create.test.ts
@@ -3,24 +3,24 @@ import {expect, test} from '../../test'
 describe('endpoints:create', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .post('/private-link/v0/databases/postgres-123')
+      .post('/private-link/v0/databases/postgres-123', {whitelisted_accounts: ['123456789012:root']})
       .reply(200, {})
     )
     .stderr()
     .stdout()
-    .command(['endpoints:create', 'postgres-123', '--account-id', 'arn:aws:iam::123456789:root', '--app', 'myapp'])
+    .command(['endpoints:create', 'postgres-123', '--account-id', '123456789012:root', '--app', 'myapp'])
     .it('creates a trusted VPC endpoint with one account id', ctx => {
       expect(ctx.stderr).to.contain('Creating Trusted VPC Endpoint... done')
     })
 
   test
     .nock('https://postgres-api.heroku.com', api => api
-      .post('/private-link/v0/databases/postgres-123')
+      .post('/private-link/v0/databases/postgres-123', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
     )
     .stderr()
     .stdout()
-    .command(['endpoints:create', 'postgres-123', '--account-id', '"arn:aws:iam::123456789:resource1', '--account-id', 'arn:aws:iam::123456789:resource2"', '--app', 'myapp'])
+    .command(['endpoints:create', 'postgres-123', '--account-id', '123456789012:resource1', '--account-id', '123456789012:resource2', '--app', 'myapp'])
     .it('creates a trusted VPC endpoint with multiple account ids', ctx => {
       expect(ctx.stderr).to.contain('Creating Trusted VPC Endpoint... done')
     })

--- a/test/commands/endpoints/create.test.ts
+++ b/test/commands/endpoints/create.test.ts
@@ -20,7 +20,7 @@ describe('endpoints:create', () => {
     )
     .stderr()
     .stdout()
-    .command(['endpoints:create', 'postgres-123', '--account-ids', 'arn:aws:iam::123456789:resource1 arn:aws:iam::123456789:resource2', '--app', 'myapp'])
+    .command(['endpoints:create', 'postgres-123', '--account-ids', '"arn:aws:iam::123456789:resource1 arn:aws:iam::123456789:resource2"', '--app', 'myapp'])
     .it('creates a trusted VPC endpoint with multiple account ids', ctx => {
       expect(ctx.stderr).to.contain('Creating Trusted VPC Endpoint... done')
     })


### PR DESCRIPTION
Split on spaces instead of commas for account ids, in order to support ARNs which may contain commas.

Tracked here: https://trello.com/c/FwmsruC0/75-bug-cli-does-not-account-for-commas-in-aws-iam-arn